### PR TITLE
ci: pass SSH_PORT through to appleboy/ssh-action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,7 @@ jobs:
         uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           script: |


### PR DESCRIPTION
The host listens on a non-default port; without `port:` the action defaults to 22 and the SSH connection fails before the deploy script ever runs. Sourcing the value from a new SSH_PORT secret keeps the port off the workflow file (and out of git history) and falls through to 22 when the secret is unset.