### PR TITLE
fix(deploy): prepend Bun + PM2 install dirs to PATH

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,6 +4,12 @@
 
 set -euo pipefail
 
+# appleboy/ssh-action runs a non-interactive non-login shell, so the host's
+# ~/.bashrc / ~/.profile (where Bun and PM2 add themselves to PATH) is
+# never sourced. Re-add both binaries' default install dirs explicitly so
+# `bun` and `pm2` resolve regardless of how this script was invoked.
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
 BACKUPS_DIR="prisma/backups"
 KEEP_BACKUPS=10
 


### PR DESCRIPTION
appleboy/ssh-action runs a non-interactive non-login shell, so the host's ~/.bashrc and ~/.profile — which is where the Bun installer adds ~/.bun/bin to PATH — never gets sourced. The first `bun` invocation in the deploy script crashes with "command not found" even though Bun is installed.

Prepend $HOME/.bun/bin, $HOME/.local/bin, and /usr/local/bin to PATH at the top of the script so `bun` and `pm2` resolve regardless of how the script is invoked.