### PR TITLE
fix(deploy): upgrade Bun on every deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,6 +10,11 @@ set -euo pipefail
 # `bun` and `pm2` resolve regardless of how this script was invoked.
 export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
 
+# Keep the host's Bun current. Lockfiles are written by recent Bun in dev
+# and CI; an older host Bun fails to parse them ("Outdated lockfile
+# version"). `bun upgrade` is idempotent and safe when already current.
+bun upgrade
+
 BACKUPS_DIR="prisma/backups"
 KEEP_BACKUPS=10
 


### PR DESCRIPTION
The host has Bun 1.1.0 but lockfiles are written by recent Bun locally and in CI, so `bun install --frozen-lockfile` errors with "Outdated lockfile version" and the deploy bails before the bot ever reloads. `bun upgrade` is idempotent (no-ops when current) and keeps the host on the same Bun the lockfile expects.

Done up-front so the upgrade itself runs on the OLD Bun (which can upgrade itself fine) before anything else is asked of it.