### PR TITLE
ci: optionally notify a Discord webhook on deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,3 +29,60 @@ jobs:
             cd Projects/azalea
             git pull origin main
             bash scripts/deploy.sh
+
+      - name: Notify Discord
+        # Always runs so failures are reported too. Becomes a no-op
+        # silently when the DISCORD_WEBHOOK_URL secret is unset, which
+        # makes the notification fully opt-in.
+        if: always()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          STATUS: ${{ job.status }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+          ACTOR: ${{ github.event.workflow_run.actor.login }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL not set; skipping notification."
+            exit 0
+          fi
+
+          case "$STATUS" in
+            success)   COLOR=3066993;  TITLE="✅ azalea deploy succeeded";;
+            failure)   COLOR=15158332; TITLE="❌ azalea deploy failed";;
+            cancelled) COLOR=10070709; TITLE="🟤 azalea deploy cancelled";;
+            *)         COLOR=10070709; TITLE="ℹ️ azalea deploy ${STATUS}";;
+          esac
+
+          SHORT_SHA="${SHA:0:7}"
+          FIRST_LINE="$(printf '%s' "$MESSAGE" | head -1)"
+
+          jq -n \
+            --arg title "$TITLE" \
+            --argjson color "$COLOR" \
+            --arg description "$FIRST_LINE" \
+            --arg repo "$REPO" \
+            --arg branch "$BRANCH" \
+            --arg short_sha "$SHORT_SHA" \
+            --arg full_sha "$SHA" \
+            --arg actor "$ACTOR" \
+            --arg run_url "$RUN_URL" \
+            '{
+               embeds: [{
+                 title: $title,
+                 url: $run_url,
+                 color: $color,
+                 description: $description,
+                 fields: [
+                   { name: "Repo",   value: $repo,                                                                   inline: true },
+                   { name: "Branch", value: $branch,                                                                 inline: true },
+                   { name: "Commit", value: ("[`" + $short_sha + "`](https://github.com/" + $repo + "/commit/" + $full_sha + ")"), inline: true },
+                   { name: "Actor",  value: $actor,                                                                  inline: true }
+                 ],
+                 timestamp: (now | todate)
+               }]
+             }' \
+          | curl -fsS -X POST -H "Content-Type: application/json" --data-binary @- "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
Adds a `Notify Discord` step that runs after `Deploy` with `if: always()` so successes, failures, and cancellations are all reported. The first thing the step does is check
`$DISCORD_WEBHOOK_URL`; if the secret isn't set, it logs a single "skipping" line and exits 0, so the notifier is fully opt-in — set the secret and it lights up, leave it unset and the step is a no-op.

Embed shape:
- Title: ✅/❌/🟤 azalea deploy <status>
- Color: green / red / grey
- Description: first line of the commit message
- URL: the originating CI workflow-run page
- Fields (all inline): Repo, Branch, Commit (clickable), Actor
- Timestamp: ISO 8601, rendered as relative by Discord

Payload is built with `jq` (pre-installed on ubuntu-latest) using --arg/--argjson so commit messages with quotes, newlines, or `$` can't break the JSON, then piped to `curl --data-binary @-` for a single round-trip to the webhook.

Workflow_run is the trigger, so we read the originating commit's sha/branch/message/actor and the run URL from
github.event.workflow_run.* — github.sha would point at the default branch tip, which is wrong for our gating model.