### PR TITLE
fix(cd): skip Sentry release when SENTRY_PROJECT is unset

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,9 +41,11 @@ jobs:
           fetch-depth: 0
 
       - name: Sentry release
-        # Becomes a no-op silently when SENTRY_AUTH_TOKEN is unset, which
-        # makes the release step fully opt-in. Failures are non-fatal —
-        # the deploy already succeeded; release tagging is best-effort.
+        # Becomes a no-op silently when any of the required Sentry inputs
+        # are unset, which makes the release step fully opt-in. Failures
+        # are non-fatal — the deploy already succeeded; release tagging
+        # is best-effort. SENTRY_ORG is optional with an org-level auth
+        # token (the org is embedded); user-level tokens require it.
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
@@ -51,6 +53,11 @@ jobs:
         run: |
           if [ -z "$SENTRY_AUTH_TOKEN" ]; then
             echo "SENTRY_AUTH_TOKEN not set; skipping Sentry release."
+            exit 0
+          fi
+          if [ -z "$SENTRY_PROJECT" ]; then
+            echo "SENTRY_PROJECT not set; skipping Sentry release."
+            echo "Set the SENTRY_PROJECT repo variable to the project slug to enable."
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

The Sentry release step in CD only gated on `SENTRY_AUTH_TOKEN`. With the token set but `SENTRY_PROJECT` repo variable still unset, the workflow proceeded and `sentry-cli releases new` failed with `Invalid project ids or slugs`, breaking the entire CD job (deploy already succeeded; release tagging is meant to be best-effort).

Add a second skip-check for `SENTRY_PROJECT` so the step no-ops cleanly when project isn't configured. Comment also clarifies that `SENTRY_ORG` is optional with org-level auth tokens (org is embedded in the token) and only required for user-level tokens.

## Test plan

- [ ] Merge and trigger a deploy without the `SENTRY_PROJECT` repo variable set: confirm Sentry release step prints "skipping" and exits 0, deploy + Discord notify continue.
- [ ] Set `SENTRY_PROJECT` to a valid project slug, trigger deploy: confirm release is created in Sentry.