### PR TITLE
fix(deploy): only reload the azalea pm2 app

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,4 +30,4 @@ fi
 
 bun run db:migrate
 
-( cd .. && pm2 reload ecosystem.config.js )
+( cd .. && pm2 reload ecosystem.config.js --only azalea --update-env )


### PR DESCRIPTION
## Summary

Cherry-pick of `ee0c06b` from the stale `fix/deploy-only-azalea` branch onto current main.

`scripts/deploy.sh` calls `pm2 reload ecosystem.config.js`, which reloads every app the file defines — so a bot deploy was bouncing the editor too. The editor has its own deploy pipeline that backs up its own state and runs its own health check, so reloading it from the bot's deploy is at best wasted work and at worst a stale-process fight if the editor is mid-deploy.

Mirror the editor's `deploy.sh`: scope the reload with `--only azalea` and pass `--update-env` so the bot picks up env changes from the resolved ecosystem entry.

## Test plan

- [ ] Merge and trigger a deploy: confirm pm2 logs show only `azalea` reloading, the editor process keeps its uptime.
- [ ] Confirm `/healthz` flips ready after the new bot process boots.