### PR TITLE
chore(deploy): gzip database backups and trim retention to 3

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,7 +20,7 @@ bash scripts/deploy.sh
 `scripts/deploy.sh` handles the rest:
 
 1. `bun install --frozen-lockfile --production` — production dependencies only.
-2. **Backup the SQLite database** to `prisma/backups/azalea.db.<UTC-timestamp>`. The 10 most recent backups are retained.
+2. **Backup the SQLite database** to `prisma/backups/azalea.db.<UTC-timestamp>.gz` (gzipped). The 3 most recent backups are retained.
 3. `bun run db:migrate` — apply pending Prisma migrations.
 4. `pm2 reload ecosystem.config.js` — graceful reload.
 
@@ -45,7 +45,7 @@ Configure these in the GitHub repo settings:
 The deploy script is just bash — you can run it locally on the host to reproduce or roll back. To restore from a backup:
 
 ```sh
-cp prisma/backups/azalea.db.<timestamp> prisma/azalea.db
+gunzip -c prisma/backups/azalea.db.<timestamp>.gz > prisma/azalea.db
 pm2 reload ecosystem.config.js
 ```
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,13 +16,13 @@ export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
 bun upgrade
 
 BACKUPS_DIR="prisma/backups"
-KEEP_BACKUPS=10
+KEEP_BACKUPS=3
 
 bun install --frozen-lockfile --production
 
 if [[ -f prisma/azalea.db ]]; then
   mkdir -p "$BACKUPS_DIR"
-  cp prisma/azalea.db "$BACKUPS_DIR/azalea.db.$(date -u +%Y%m%dT%H%M%SZ)"
+  gzip -c prisma/azalea.db > "$BACKUPS_DIR/azalea.db.$(date -u +%Y%m%dT%H%M%SZ).gz"
   find "$BACKUPS_DIR" -maxdepth 1 -type f -name 'azalea.db.*' \
     | sort -r | tail -n "+$((KEEP_BACKUPS + 1))" \
     | xargs -I {} rm -- "{}"


### PR DESCRIPTION
SQLite snapshots compress well, so gzipping cuts the disk footprint of prisma/backups/. Drop retention from 10 to 3 — only the most recent snapshots are useful for a rollback, the rest just held disk.